### PR TITLE
Strict vs lenient mode

### DIFF
--- a/docs/Sample.elm
+++ b/docs/Sample.elm
@@ -1,0 +1,49 @@
+module Sample exposing (sampleJson)
+
+import Json.Encode exposing (Value)
+
+
+sampleJson : Value
+sampleJson =
+    Json.Encode.object
+        [ ( "store"
+          , Json.Encode.object
+                [ ( "book"
+                  , Json.Encode.list identity
+                        [ Json.Encode.object
+                            [ ( "category", Json.Encode.string "reference" )
+                            , ( "author", Json.Encode.string "Nigel Rees" )
+                            , ( "title", Json.Encode.string "Sayings of the Century" )
+                            , ( "price", Json.Encode.float 8.95 )
+                            ]
+                        , Json.Encode.object
+                            [ ( "category", Json.Encode.string "fiction" )
+                            , ( "author", Json.Encode.string "Evelyn Waugh" )
+                            , ( "title", Json.Encode.string "Sword of Honour" )
+                            , ( "price", Json.Encode.float 12.99 )
+                            ]
+                        , Json.Encode.object
+                            [ ( "category", Json.Encode.string "fiction" )
+                            , ( "author", Json.Encode.string "Herman Melville" )
+                            , ( "title", Json.Encode.string "Moby Dick" )
+                            , ( "isbn", Json.Encode.string "0-553-21311-3" )
+                            , ( "price", Json.Encode.float 8.99 )
+                            ]
+                        , Json.Encode.object
+                            [ ( "category", Json.Encode.string "fiction" )
+                            , ( "author", Json.Encode.string "J. R. R. Tolkien" )
+                            , ( "title", Json.Encode.string "The Lord of the Rings" )
+                            , ( "isbn", Json.Encode.string "0-395-19395-8" )
+                            , ( "price", Json.Encode.float 22.99 )
+                            ]
+                        ]
+                  )
+                , ( "bicycle"
+                  , Json.Encode.object
+                        [ ( "color", Json.Encode.string "red" )
+                        , ( "price", Json.Encode.float 19.95 )
+                        ]
+                  )
+                ]
+          )
+        ]

--- a/docs/sample.json
+++ b/docs/sample.json
@@ -1,0 +1,36 @@
+{
+    "store": {
+        "book": [
+            {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            },
+            {
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12.99
+            },
+            {
+                "category": "fiction",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8.99
+            },
+            {
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22.99
+            }
+        ],
+        "bicycle": {
+            "color": "red",
+            "price": 19.95
+        }
+    }
+}

--- a/src/Utils/ListUtils.elm
+++ b/src/Utils/ListUtils.elm
@@ -1,6 +1,22 @@
 module Utils.ListUtils exposing (..)
 
 
+collectOkValues : List (Result e a) -> List a
+collectOkValues list =
+    -- Collects all the Ok values in a List of Results
+    let
+        f : Result e a -> List a -> List a
+        f result acc =
+            case result of
+                Ok a ->
+                    a :: acc
+
+                Err _ ->
+                    acc
+    in
+    List.foldr f [] list
+
+
 traverseMaybe : (a -> Maybe b) -> List a -> Maybe (List b)
 traverseMaybe f list =
     -- Inspired by the traverse method on https://typelevel.org/cats/api/cats/Traverse.html

--- a/tests/JsonPath/ExtractorSpec.elm
+++ b/tests/JsonPath/ExtractorSpec.elm
@@ -14,19 +14,19 @@ suite =
         [ describe "run method"
             [ test "should extract the root element" <|
                 \_ ->
-                    equal (JsonPath.Extractor.run "$" sampleJson) (Ok sampleJson)
+                    equal (JsonPath.Extractor.run "$" False sampleJson) (Ok sampleJson)
             , describe "should extract the elements in a path comprising a wildcard selector"
                 [ test "$.store.book[*]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[*]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[*]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book0, book1, book2, book3 ]))
                 , test "$.store.book[*].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[*].author" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[*].author" False sampleJson)
                             (Ok (Json.Encode.list Json.Encode.string [ "Nigel Rees", "Evelyn Waugh", "Herman Melville", "J. R. R. Tolkien" ]))
                 , test "$.store[*]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store[*]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store[*]" False sampleJson)
                             (Ok
                                 (Json.Encode.list identity
                                     [ bicycle
@@ -38,19 +38,19 @@ suite =
             , describe "should extract the elements in a path comprising a slice selector"
                 [ test "$.store.book[1:3]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[1:3]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[1:3]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book1, book2 ]))
                 , test "$.store.book[2:]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[2:]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[2:]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book2, book3 ]))
                 , test "$.store.book[-3:]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[-3:]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[-3:]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book1, book2, book3 ]))
                 , test "$.store.book[:].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[:].author" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[:].author" False sampleJson)
                             (Ok
                                 (Json.Encode.list Json.Encode.string
                                     [ "Nigel Rees"
@@ -62,49 +62,49 @@ suite =
                             )
                 , test "$.store.book[0:4:2]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[0:4:2]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[0:4:2]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book0, book2 ]))
                 , test "$.store.book[::3]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[::3]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[::3]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book0, book3 ]))
                 , test "$.store.book[::-1]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[::-1]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[::-1]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book3, book2, book1, book0 ]))
                 , test "$.store.book[::-2].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[::-2].author" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[::-2].author" False sampleJson)
                             (Ok (Json.Encode.list Json.Encode.string [ "Herman Melville", "Nigel Rees" ]))
                 ]
             , describe "should extract the elements in a path comprising an index selector with a single value"
                 [ test "$.store.book[1]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[1]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[1]" False sampleJson)
                             (Ok book1)
                 , test "$.store.book[-2].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[-2].author" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[-2].author" False sampleJson)
                             (Ok (Json.Encode.string "Herman Melville"))
                 ]
             , describe "should extract the elements in a path comprising an index selector with multiple values"
                 [ test "$.store.book[1,3]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[1,3]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[1,3]" False sampleJson)
                             (Ok (Json.Encode.list identity [ book1, book3 ]))
                 , test "$.store.book[-2,-1].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[-2,-1].title" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[-2,-1].title" False sampleJson)
                             (Ok (Json.Encode.list Json.Encode.string [ "Moby Dick", "The Lord of the Rings" ]))
                 ]
             , describe "should extract the elements in a path comprising a key selector with multiple values"
                 [ test "$.store.book[1][author,title]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[1][author,title]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[1][author,title]" False sampleJson)
                             (Ok (Json.Encode.list Json.Encode.string [ "Evelyn Waugh", "Sword of Honour" ]))
                 , test "$.store.book[-2,-1][author,title]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[-2,-1][author,title]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[-2,-1][author,title]" False sampleJson)
                             (Ok
                                 (Json.Encode.list Json.Encode.string
                                     [ "Herman Melville"
@@ -118,30 +118,84 @@ suite =
             , describe "should correctly report an 'index not found' error"
                 [ test "$.store.book[5].author" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[5].author" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[5].author" False sampleJson)
                             (Err (IndexNotFound [ DownKey "book", DownKey "store" ] 5))
                 ]
             , describe "should correctly report a 'key not found' error"
                 [ test "$.store.pet[*]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.pet[*]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.pet[*]" False sampleJson)
                             (Err (KeyNotFound [ DownKey "store" ] "pet"))
                 , test "$.store.book[0][author,publisher]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[0][author,publisher]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[0][author,publisher]" False sampleJson)
                             (Err (KeyNotFound [ DownIndex 0, DownKey "book", DownKey "store" ] "publisher"))
                 ]
             , describe "should correctly report a 'not a JSON array' error"
                 [ test "$.store[1]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store[1]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store[1]" False sampleJson)
                             (Err (NotAJsonArray [ DownKey "store" ]))
                 ]
             , describe "should correctly report a 'not a JSON array nor an object' error"
                 [ test "$.store.book[1].author[*]" <|
                     \_ ->
-                        equal (JsonPath.Extractor.run "$.store.book[1].author[*]" sampleJson)
+                        equal (JsonPath.Extractor.run "$.store.book[1].author[*]" False sampleJson)
                             (Err (NotAJsonArrayNorAnObject [ DownKey "author", DownIndex 1, DownKey "book", DownKey "store" ]))
+                ]
+            , describe "should be ignore missing indices and keys when strict = False and more than one result could be returned"
+                [ describe "$.store.book[:].isbn"
+                    [ test "strict = True" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.book[:].isbn" True sampleJson)
+                                (Err (KeyNotFound [ DownIndex 0, DownKey "book", DownKey "store" ] "isbn"))
+                    , test "strict = False" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.book[:].isbn" False sampleJson)
+                                (Ok (Json.Encode.list Json.Encode.string [ "0-553-21311-3", "0-395-19395-8" ]))
+                    ]
+                , describe "$.store[*][0]"
+                    [ test "strict = True" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store[*][0]" True sampleJson)
+                                (Err (NotAJsonArray [ DownKey "bicycle", DownKey "store" ]))
+                    , test "strict = False" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store[*][0]" False sampleJson)
+                                (Ok (Json.Encode.list identity [ book0 ]))
+                    ]
+                , describe "$.store[*][5]"
+                    [ test "strict = True" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store[*][5]" True sampleJson)
+                                (Err (NotAJsonArray [ DownKey "bicycle", DownKey "store" ]))
+                    , test "strict = False" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store[*][5]" False sampleJson)
+                                (Ok (Json.Encode.list identity []))
+                    ]
+                ]
+            , describe "should remain strict even with strict = False when only one result could be returned"
+                [ describe "$.store.pet"
+                    [ test "strict = True" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.pet" True sampleJson)
+                                (Err (KeyNotFound [ DownKey "store" ] "pet"))
+                    , test "strict = False" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.pet" False sampleJson)
+                                (Err (KeyNotFound [ DownKey "store" ] "pet"))
+                    ]
+                , describe "$.store.book[5]"
+                    [ test "strict = True" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.book[5]" True sampleJson)
+                                (Err (IndexNotFound [ DownKey "book", DownKey "store" ] 5))
+                    , test "strict = False" <|
+                        \_ ->
+                            equal (JsonPath.Extractor.run "$.store.book[5]" False sampleJson)
+                                (Err (IndexNotFound [ DownKey "book", DownKey "store" ] 5))
+                    ]
                 ]
             ]
         ]


### PR DESCRIPTION
Toying around with the idea of strict vs lenient modes, where the latter would discard errors such as `IndexNotFound` or `KeyNotFound` when the JSONPath expression can return multiple values.